### PR TITLE
fix: uppercase base URLs in services

### DIFF
--- a/services/auth/auth.service.ts
+++ b/services/auth/auth.service.ts
@@ -2,7 +2,7 @@ import { request } from '@/utils';
 
 import { LoginPayload, LoginResponse } from './auth.types';
 
-const BASE_URL = '/auth';
+const BASE_URL = '/Auth';
 
 export const AuthService = {
   async login(payload: LoginPayload): Promise<LoginResponse> {

--- a/services/chamados/chamado.service.ts
+++ b/services/chamados/chamado.service.ts
@@ -2,7 +2,7 @@ import { request } from '@/utils';
 
 import { Chamado, ChamadoPayload } from './chamado.types';
 
-const BASE_URL = '/chamados';
+const BASE_URL = '/Chamados';
 
 export const ChamadoService = {
   add(payload: ChamadoPayload): Promise<string> {

--- a/services/tecnicos/tecnico.service.ts
+++ b/services/tecnicos/tecnico.service.ts
@@ -2,7 +2,7 @@ import { request } from '@/utils';
 
 import { Tecnico } from './tecnico.types';
 
-const BASE_URL = '/tecnico';
+const BASE_URL = '/Tecnico';
 
 export const TecnicoService = {
   list(): Promise<Tecnico[] | string> {


### PR DESCRIPTION
A BASE_URL dos services agora está em PascalCase, como a API.