### PR TITLE
feat: add UserContext and rename getById methods to getByEmail

### DIFF
--- a/app/(private)/chamados/components/ChamadoForm/index.tsx
+++ b/app/(private)/chamados/components/ChamadoForm/index.tsx
@@ -4,8 +4,7 @@ import { Dropdown } from 'react-native-element-dropdown';
 
 import { BaseForm } from '@/components/forms';
 import { TextField } from '@/components/inputs';
-import { ChamadoService } from '@/services/chamados';
-import { ChamadoPayload, ChamadoPrioridade, ChamadoStatus } from '@/services/chamados/chamado.types';
+import { ChamadoPayload, ChamadoPrioridade, ChamadoService , ChamadoStatus } from '@/services/chamados';
 import { showAlert } from '@/utils';
 
 import styles from './style';

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,13 @@
 import { Slot } from 'expo-router';
 
-import { AuthProvider } from '@/contexts';
+import { AuthProvider, UserProvider } from '@/contexts';
 
 export default function RootLayout() {
   return (
     <AuthProvider>
-      <Slot />
+      <UserProvider>
+        <Slot />
+      </UserProvider>
     </AuthProvider>
   );
 }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -33,7 +33,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     (async (): Promise<void> => {
       const storedToken = await getToken();
       if (storedToken) {
-        setToken(storedToken);
+        setToken(storedToken); // restaura a sessão se o token existir no storage
       }
       setIsLoading(false); // indica que o contexto terminou de carregar
     })();

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -2,10 +2,11 @@ import React, { createContext, useEffect, useState } from 'react';
 
 import { AuthService, LoginPayload } from '@/services';
 import { registerLogoutCallback } from '@/services/api';
-import { getToken, removeToken, saveToken } from '@/services/auth/storage';
+import { getEmail, getToken, removeEmail, removeToken, saveEmail, saveToken } from '@/services/auth/storage';
 
 interface AuthContextProps {
   token: string | null;
+  email: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (payload: LoginPayload) => Promise<void>;
@@ -14,6 +15,7 @@ interface AuthContextProps {
 
 export const AuthContext = createContext<AuthContextProps>({
   token: null,
+  email: null,
   isAuthenticated: false,
   login: async () => {},
   logout: async () => {},
@@ -26,6 +28,7 @@ interface AuthProviderProps {
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [token, setToken] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
   const isAuthenticated = !!token;
   const [isLoading, setIsLoading] = useState(true);
 
@@ -35,19 +38,32 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       if (storedToken) {
         setToken(storedToken); // restaura a sessão se o token existir no storage
       }
+
+      const storedEmail = await getEmail();
+      if (storedEmail) {
+        setEmail(storedEmail);
+      }
+
       setIsLoading(false); // indica que o contexto terminou de carregar
     })();
   }, []);
 
   const login = async (payload: LoginPayload): Promise<void> => {
     const data = await AuthService.login(payload);
+
     await saveToken(data.token); // armazena o token no storage
     setToken(data.token); // atualiza o estado do token
+
+    await saveEmail(payload.email);
+    setEmail(payload.email);
   };
 
   const logout = async (): Promise<void> => {
     await removeToken();
     setToken(null);
+
+    await removeEmail();
+    setEmail(null);
   };
 
   // registra o logout global para ser usado pelo interceptor
@@ -56,7 +72,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ token, isAuthenticated, isLoading, login, logout }}>
+    <AuthContext.Provider value={{ token, email, isAuthenticated, isLoading, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useEffect, useState } from 'react';
+
+import { useAuth } from '@/hooks';
+import { Usuario } from '@/services';
+import { UsuarioService } from '@/services/usuarios/usuario.service';
+import { showAlert } from '@/utils';
+
+interface UserContextProps {
+  user: Usuario | null;
+  loadingUser: boolean;
+  refreshUser: () => Promise<void>;
+}
+
+interface UserProviderProps {
+  children: React.ReactNode;
+}
+
+export const UserContext = createContext<UserContextProps>({
+  user: null,
+  loadingUser: true,
+  refreshUser: async () => {},
+});
+
+export const UserProvider = ({ children }: UserProviderProps) => {
+  const { token, email, isAuthenticated } = useAuth();
+  const [user, setUser] = useState<Usuario | null>(null);
+  const [loadingUser, setLoadingUser] = useState(true);
+
+  const fetchUser = async (): Promise<void> => {
+    if (!isAuthenticated || !token || !email) {
+      setUser(null);
+      setLoadingUser(false);
+      return;
+    }
+
+    try {
+      const response: Usuario | string = await UsuarioService.getByEmail(email);
+      if (typeof response === 'string') {
+        throw new Error(response);
+      }
+
+      setUser(response);
+    } catch {
+      showAlert('Erro', 'Não foi possível carregar os dados do usuário.');
+    } finally {
+      setLoadingUser(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUser();
+  }, [token, email, isAuthenticated]);
+
+  return (
+    <UserContext.Provider value={{ user, loadingUser, refreshUser: fetchUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthContext';
+export * from './UserContext';

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useAuth';
+export * from './useUser';

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+
+import { UserContext } from '@/contexts';
+
+export const useUser = () => useContext(UserContext);

--- a/services/auth/storage.ts
+++ b/services/auth/storage.ts
@@ -25,3 +25,27 @@ export const removeToken = async (): Promise<void> => {
   }
   await SecureStore.deleteItemAsync(TOKEN_KEY);
 };
+
+// Email storage functions - provisory implementation
+export const saveEmail = async (email: string): Promise<void> => {
+  if (Platform.OS === 'web') {
+    localStorage.setItem('Suptech_email', email);
+    return;
+  }
+  await SecureStore.setItemAsync('Suptech_email', email);
+};
+
+export const getEmail = async (): Promise<string | null> => {
+  if (Platform.OS === 'web') {
+    return localStorage.getItem('Suptech_email');
+  }
+  return await SecureStore.getItemAsync('Suptech_email');
+};
+
+export const removeEmail = async (): Promise<void> => {
+  if (Platform.OS === 'web') {
+    localStorage.removeItem('Suptech_email');
+    return;
+  }
+  await SecureStore.deleteItemAsync('Suptech_email');
+};

--- a/services/chamados/chamado.service.ts
+++ b/services/chamados/chamado.service.ts
@@ -13,8 +13,8 @@ export const ChamadoService = {
     return request('get', `${BASE_URL}/Listar`);
   },
 
-  getById(id: string): Promise<Chamado> {
-    return request('get', `${BASE_URL}/Obter/${id}`);
+  getByEmail(email: string): Promise<Chamado> {
+    return request('get', `${BASE_URL}/Obter/${email}`);
   },
 
   edit(id: string, payload: ChamadoPayload): Promise<string> {

--- a/services/tecnicos/tecnico.service.ts
+++ b/services/tecnicos/tecnico.service.ts
@@ -9,7 +9,7 @@ export const TecnicoService = {
     return request<string | Tecnico[]>('get', `${BASE_URL}/Listar`);
   },
 
-  getById(id: string): Promise<Tecnico | string> {
-    return request<string | Tecnico>('get', `${BASE_URL}/Obter/${id}`);
+  getByEmail(email: string): Promise<Tecnico | string> {
+    return request<string | Tecnico>('get', `${BASE_URL}/ObterPorEmail/${email}`);
   },
 };

--- a/services/usuarios/usuario.service.ts
+++ b/services/usuarios/usuario.service.ts
@@ -13,8 +13,8 @@ export const UsuarioService = {
     return request('get', `${BASE_URL}/Listar`);
   },
 
-  getById(id: string): Promise<Usuario | string> {
-    return request('get', `${BASE_URL}/Obter/${id}`);
+  getByEmail(email: string): Promise<Usuario | string> {
+    return request('get', `${BASE_URL}/ObterPorEmail/${email}`);
   },
 
   edit(id: string, payload: UsuarioPayload): Promise<string> {


### PR DESCRIPTION
Foi criado um estado global para guardar informações do usuário - o UserContext, usado com o hook useUser.

Foram alteradas os métodos dos serviços de entidade: getById --> getByEmail.