### PR TITLE
refactor: remove duplicated error alerts in API service

### DIFF
--- a/components/headers/BaseHeader/index.tsx
+++ b/components/headers/BaseHeader/index.tsx
@@ -13,7 +13,7 @@ interface BaseHeaderProps {
 }
 
 export default function BaseHeader({ title, ...rest }: BaseHeaderProps) {
-  const { logout, authLoading } = useAuth();
+  const { logout, token } = useAuth();
 
   async function handleLogout(): Promise<void> {
     await logout();
@@ -24,7 +24,7 @@ export default function BaseHeader({ title, ...rest }: BaseHeaderProps) {
     <SafeAreaView edges={['top']} style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>{title}</Text>
-        {authLoading &&
+        {token &&
           <BaseButton onPress={handleLogout} style={styles.logoutButton}>
             Sair
           </BaseButton>

--- a/services/api.ts
+++ b/services/api.ts
@@ -40,18 +40,20 @@ api.interceptors.response.use(
     const status: number = response.status;
     const message: string = response.data?.message || 'Ocorreu um erro inesperado. Tente novamente.';
 
-    if (status !== 401) {
-      showAlert('Erro', message);
-      return Promise.reject(error);
+    if (status === 401) {
+      showAlert('Sessão expirada', 'Por favor, faça login novamente.');
+
+      if (logoutCallback) {
+        await logoutCallback();
+      }
     }
 
-    showAlert('Sessão expirada', 'Por favor, faça login novamente.');
 
-    if (logoutCallback) {
-      await logoutCallback();
-    }
-
-    return Promise.reject(error);
+    return Promise.reject({
+      status,
+      message,
+      original: error,
+    });
   }
 );
 


### PR DESCRIPTION
O serviço da API foi refatorado para não exibir alertas de erro duplicados.

A exibição do botão de logout no BaseHeader foi corrigida.