### PR TITLE
style: adjust logout button visibility to show only on private screens

### DIFF
--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -18,7 +18,7 @@ export default function PrivateLayout() {
     <Stack
       screenOptions={{
         headerShown: true,
-        header: () => <BaseHeader title="Suptech" />,
+        header: () => <BaseHeader title="Suptech" showLogout={true} />,
       }}
     />
   );

--- a/components/headers/BaseHeader/index.tsx
+++ b/components/headers/BaseHeader/index.tsx
@@ -21,13 +21,11 @@ export default function BaseHeader({ title, showLogout = false, ...rest }: BaseH
     router.replace('/(public)/login');
   }
 
-  const shouldShowLogoutButton = token && showLogout;
-
   return (
     <SafeAreaView edges={['top']} style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>{title}</Text>
-        {shouldShowLogoutButton &&
+        {showLogout && token &&
           <BaseButton onPress={handleLogout} style={styles.logoutButton}>
             Sair
           </BaseButton>

--- a/components/headers/BaseHeader/index.tsx
+++ b/components/headers/BaseHeader/index.tsx
@@ -10,9 +10,10 @@ import styles from './style';
 
 interface BaseHeaderProps {
   title: string;
+  showLogout?: boolean;
 }
 
-export default function BaseHeader({ title, ...rest }: BaseHeaderProps) {
+export default function BaseHeader({ title, showLogout = false, ...rest }: BaseHeaderProps) {
   const { logout, token } = useAuth();
 
   async function handleLogout(): Promise<void> {
@@ -20,11 +21,13 @@ export default function BaseHeader({ title, ...rest }: BaseHeaderProps) {
     router.replace('/(public)/login');
   }
 
+  const shouldShowLogoutButton = token && showLogout;
+
   return (
     <SafeAreaView edges={['top']} style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>{title}</Text>
-        {token &&
+        {shouldShowLogoutButton &&
           <BaseButton onPress={handleLogout} style={styles.logoutButton}>
             Sair
           </BaseButton>


### PR DESCRIPTION
Foi adicionado uma prop para controlar a  exibição do botão de logout no BaseHeader.