### PR TITLE
feat: create toast context, provider and hook to show toast notifications

### DIFF
--- a/app/(private)/chamados/components/ChamadoForm/index.tsx
+++ b/app/(private)/chamados/components/ChamadoForm/index.tsx
@@ -4,10 +4,9 @@ import { Dropdown } from 'react-native-element-dropdown';
 
 import { BaseForm } from '@/components/forms';
 import { TextField } from '@/components/inputs';
-import { useUser } from '@/hooks';
+import { useToast,useUser } from '@/hooks';
 import { Usuario } from '@/services';
 import { ChamadoPayload, ChamadoPrioridade, ChamadoService , ChamadoStatus } from '@/services/chamados';
-import { showAlert } from '@/utils';
 
 import styles from './style';
 
@@ -18,6 +17,7 @@ interface Props {
 export function ChamadoForm({ onSuccess }: Props) {
   const { user } = useUser();
   const userData: Usuario = user as Usuario; // necessário pois user pode ser Tecnico também.
+  const { showToast } = useToast();
 
   const defaultForm: ChamadoPayload = {
     descricao: '',
@@ -38,7 +38,6 @@ export function ChamadoForm({ onSuccess }: Props) {
     setErrors({ ...errors, [key]: null });
   };
 
-
   const validateForm = (f: ChamadoPayload): boolean => {
     const newErrors: Record<string, string | null> = {};
     let isValid: boolean = true;
@@ -56,18 +55,18 @@ export function ChamadoForm({ onSuccess }: Props) {
 
     const handleSubmit = async (): Promise<void> => {
       if (!validateForm(form)) {
-        showAlert('Campos obrigatórios', 'Preencha todos os campos antes de continuar.');
+        showToast('Preencha todos os campos antes de continuar.');
         return;
       }
 
       setLoading(true);
       try {
         await ChamadoService.create(form);
-        showAlert('Sucesso', 'Chamado criado com sucesso!');
+        showToast('Chamado criado com sucesso!');
         onSuccess();
         setForm(defaultForm);
       } catch {
-        showAlert('Erro', 'Não foi possível criar o chamado.');
+        showToast('Não foi possível criar o chamado.');
       } finally {
         setLoading(false);
       }

--- a/app/(private)/chamados/components/ChamadoForm/index.tsx
+++ b/app/(private)/chamados/components/ChamadoForm/index.tsx
@@ -53,24 +53,24 @@ export function ChamadoForm({ onSuccess }: Props) {
     return isValid;
   };
 
-    const handleSubmit = async (): Promise<void> => {
-      if (!validateForm(form)) {
-        showToast('Preencha todos os campos antes de continuar.');
-        return;
-      }
+  const handleSubmit = async (): Promise<void> => {
+    if (!validateForm(form)) {
+      showToast('Preencha todos os campos antes de continuar.');
+      return;
+    }
 
-      setLoading(true);
-      try {
-        await ChamadoService.create(form);
-        showToast('Chamado criado com sucesso!');
-        onSuccess();
-        setForm(defaultForm);
-      } catch {
-        showToast('Não foi possível criar o chamado.');
-      } finally {
-        setLoading(false);
-      }
-    };
+    setLoading(true);
+    try {
+      await ChamadoService.create(form);
+      showToast('Chamado criado com sucesso!');
+      onSuccess();
+      setForm(defaultForm);
+    } catch {
+      showToast('Não foi possível criar o chamado.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
     const prioridadeOptions = Object.values(ChamadoPrioridade).map((p) => ({
       label: p,

--- a/app/(private)/chamados/components/DeleteChamadoModal/index.tsx
+++ b/app/(private)/chamados/components/DeleteChamadoModal/index.tsx
@@ -3,9 +3,9 @@ import { ActivityIndicator, Text, View } from 'react-native';
 
 import { BaseButton } from '@/components/buttons';
 import { BaseModal } from '@/components/modals';
+import { useToast } from '@/hooks';
 import { ChamadoService } from '@/services/chamados';
 import { Chamado } from '@/services/chamados/chamado.types';
-import { showAlert } from '@/utils';
 
 import styles from './style';
 
@@ -18,6 +18,7 @@ interface Props {
 
 export function DeleteChamadoModal({ chamado, visible, onClose, onSuccess }: Props) {
   const [loading, setLoading] = useState(false);
+  const { showToast } = useToast();
 
   const handleDelete = async () => {
     if (!chamado) return;
@@ -25,11 +26,11 @@ export function DeleteChamadoModal({ chamado, visible, onClose, onSuccess }: Pro
     setLoading(true);
     try {
       await ChamadoService.delete(chamado.chamadoID);
-      showAlert('Sucesso', 'Chamado excluído com sucesso!');
+      showToast('Chamado excluído com sucesso!');
       onSuccess();
       onClose();
     } catch {
-      showAlert('Erro', 'Não foi possível excluir o chamado');
+      showToast('Não foi possível excluir o chamado');
     } finally {
       setLoading(false);
     }

--- a/app/(private)/chamados/components/EditChamadoForm/index.tsx
+++ b/app/(private)/chamados/components/EditChamadoForm/index.tsx
@@ -3,9 +3,9 @@ import { ActivityIndicator, Text, View } from 'react-native';
 
 import { BaseButton } from '@/components/buttons';
 import { TextField } from '@/components/inputs';
+import { useToast } from '@/hooks';
 import { ChamadoService } from '@/services/chamados';
 import { Chamado, ChamadoPrioridade } from '@/services/chamados/chamado.types';
-import { showAlert } from '@/utils';
 
 import styles from './style';
 
@@ -19,10 +19,11 @@ export function EditChamadoForm({ chamado, onSuccess }: Props) {
   const [descricao, setDescricao] = useState(chamado.descricao);
   const [prioridade, setPrioridade] = useState(chamado.prioridade);
   const [loading, setLoading] = useState(false);
+  const { showToast } = useToast();
 
   const handleSubmit = async () => {
     if (!titulo.trim() || !descricao.trim()) {
-      showAlert('Erro', 'Preencha todos os campos');
+      showToast('Preencha todos os campos');
       return;
     }
 
@@ -37,10 +38,10 @@ export function EditChamadoForm({ chamado, onSuccess }: Props) {
         setorDoUsuario: chamado.setorDoUsuario,
         status: chamado.status,
       });
-      showAlert('Sucesso', 'Chamado atualizado com sucesso!');
+      showToast('Chamado atualizado com sucesso!');
       onSuccess();
     } catch {
-      showAlert('Erro', 'Não foi possível atualizar o chamado');
+      showToast('Não foi possível atualizar o chamado');
     } finally {
       setLoading(false);
     }

--- a/app/(private)/chamados/index.tsx
+++ b/app/(private)/chamados/index.tsx
@@ -4,10 +4,9 @@ import { ActivityIndicator, FlatList, RefreshControl, Text, View } from 'react-n
 
 import { BaseButton } from '@/components/buttons';
 import { BaseModal } from '@/components/modals';
-import { useUser } from '@/hooks';
+import { useToast,useUser  } from '@/hooks';
 import { ChamadoService } from '@/services/chamados';
 import { Chamado } from '@/services/chamados/chamado.types';
-import { showAlert } from '@/utils';
 
 import { ChamadoCard } from './components/ChamadoCard';
 import { ChamadoForm } from './components/ChamadoForm';
@@ -30,13 +29,14 @@ export default function ChamadosScreen() {
   const { user, userLoading } = useUser();
   const userEmail = user?.email || '';
   const { userType } = useUser();
+  const { showToast } = useToast();
 
   const fetchChamados = async () => {
     try {
       const data = await ChamadoService.getByEmail(userEmail);
       setChamados(data);
     } catch {
-      showAlert('Erro', 'Não foi possível buscar chamados');
+      showToast('Não foi possível buscar chamados');
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -47,7 +47,7 @@ export default function ChamadosScreen() {
     if (userLoading) return;
 
     if (userType !== 'Usuario') {
-      showAlert('Erro', 'Apenas usuários podem acessar essa tela.');
+      showToast('Apenas usuários podem acessar essa tela.');
       router.replace('/(public)/login');
       return;
     }

--- a/app/(private)/tecnico/components/TicketResponseModal/index.tsx
+++ b/app/(private)/tecnico/components/TicketResponseModal/index.tsx
@@ -4,8 +4,8 @@ import { Text, View } from 'react-native';
 import { BaseForm } from '@/components/forms';
 import { TextField } from '@/components/inputs';
 import { BaseModal } from '@/components/modals';
+import { useToast } from '@/hooks';
 import { Chamado, ChamadoService, ChamadoStatus } from '@/services/chamados';
-import { showAlert } from '@/utils';
 
 import styles from './style';
 
@@ -20,6 +20,7 @@ export function TicketResponseModal({ visible, onClose, chamado, onSuccess }: Pr
   const [response, setResponse] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   const resetForm = () => {
     setResponse('');
@@ -36,12 +37,12 @@ export function TicketResponseModal({ visible, onClose, chamado, onSuccess }: Pr
       const { chamadoID, ...apiPayload } = updatedChamado;
       await ChamadoService.update(chamado.chamadoID, apiPayload);
 
-      showAlert('Sucesso', 'Chamado respondido com sucesso!');
+      showToast('Chamado respondido com sucesso!');
       resetForm();
       onSuccess();
       onClose();
     } catch {
-      showAlert('Erro', 'Não foi possível responder o chamado.');
+      showToast('Não foi possível responder o chamado.');
     } finally {
       setLoading(false);
     }

--- a/app/(private)/tecnico/index.tsx
+++ b/app/(private)/tecnico/index.tsx
@@ -2,9 +2,8 @@ import { router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { RefreshControl, ScrollView, Text, View } from 'react-native';
 
-import { useUser } from '@/hooks';
+import { useToast,useUser } from '@/hooks';
 import { Chamado, ChamadoService } from '@/services/chamados';
-import { showAlert } from '@/utils';
 
 import { ChamadoCardTecnico } from './components/ChamadoCardTecnico';
 import { TicketResponseModal } from './components/TicketResponseModal';
@@ -17,14 +16,14 @@ export default function TecnicoScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [selectedChamado, setSelectedChamado] = useState<Chamado | null>(null);
   const { userLoading, userType } = useUser();
+  const { showToast } = useToast();
 
   const fetchChamadosPendentes = async () => {
     try {
       const pendentes = await ChamadoService.getByStatus('Pendente');
-
       setChamados(pendentes);
     } catch {
-      showAlert('Erro', 'Não foi possível buscar chamados pendentes');
+      showToast('Não foi possível buscar chamados pendentes');
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -35,7 +34,7 @@ export default function TecnicoScreen() {
     if (userLoading) return;
 
     if (userType !== 'Tecnico') {
-      showAlert('Erro', 'Apenas técnicos podem acessar essa tela.');
+      showToast('Apenas técnicos podem acessar essa tela.');
       router.replace('/(public)/login');
       return;
     }

--- a/app/(public)/login/components/loginForm/index.tsx
+++ b/app/(public)/login/components/loginForm/index.tsx
@@ -51,8 +51,8 @@ export default function LoginForm() {
       showToast('Login realizado com sucesso');
 
       router.replace('/(private)/redirect');
-    } catch {
-      showToast('Email ou senha inválidos');
+    } catch (error: any) {
+      if (error.status === 401) showToast('Email ou senha inválidos');
     } finally {
       setIsLoading(false);
     }

--- a/app/(public)/login/components/loginForm/index.tsx
+++ b/app/(public)/login/components/loginForm/index.tsx
@@ -4,8 +4,7 @@ import { Text, View } from 'react-native';
 
 import { BaseForm } from '@/components/forms';
 import { TextField } from '@/components/inputs';
-import { useAuth } from '@/hooks';
-import { showAlert } from '@/utils';
+import { useAuth , useToast } from '@/hooks';
 import { isValidEmail } from '@/utils/validation';
 
 import styles from './style';
@@ -17,6 +16,7 @@ interface LoginPayload {
 
 export default function LoginForm() {
   const { login } = useAuth();
+  const { showToast } = useToast();
 
   const [form, setForm] = useState<LoginPayload>({
     email: '',
@@ -48,11 +48,11 @@ export default function LoginForm() {
     setIsLoading(true);
     try {
       await login({ email: form.email, senha: form.senha });
-      showAlert('Sucesso', 'Login realizado com sucesso');
+      showToast('Login realizado com sucesso');
 
       router.replace('/(private)/redirect');
     } catch {
-      showAlert('Erro', 'Email ou senha inválidos');
+      showToast('Email ou senha inválidos');
     } finally {
       setIsLoading(false);
     }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,14 @@
 import { Slot } from 'expo-router';
 
-import { AuthProvider, UserProvider } from '@/contexts';
+import { AuthProvider, ToastProvider, UserProvider  } from '@/contexts';
 
 export default function RootLayout() {
   return (
     <AuthProvider>
       <UserProvider>
-        <Slot />
+        <ToastProvider>
+          <Slot />
+        </ToastProvider>
       </UserProvider>
     </AuthProvider>
   );

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,0 +1,35 @@
+import { createContext, useState } from 'react';
+import { Snackbar } from 'react-native-paper';
+
+interface ToastContetProps {
+  showToast: (msg: string) => void;
+}
+
+export const ToastContext = createContext<ToastContetProps>({
+  showToast: () => {},
+});
+
+export function ToastProvider({ children }: any) {
+  const [visible, setVisible] = useState(false);
+  const [message, setMessage] = useState('');
+
+  function showToast(msg: string) {
+    setMessage(msg);
+    setVisible(true);
+  }
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      <>
+        {children}
+        <Snackbar
+          visible={visible}
+          onDismiss={() => setVisible(false)}
+          duration={2500}
+        >
+          {message}
+        </Snackbar>
+      </>
+    </ToastContext.Provider>
+  );
+}

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
 import { Snackbar } from 'react-native-paper';
 
 import { registerToast } from './toastController';
@@ -24,6 +25,8 @@ export function ToastProvider({ children }: any) {
     registerToast(showToast);
   }, []);
 
+  const isMobile = Platform.OS !== 'web';
+
   return (
     <ToastContext.Provider value={{ showToast }}>
       <>
@@ -32,6 +35,11 @@ export function ToastProvider({ children }: any) {
           visible={visible}
           onDismiss={() => setVisible(false)}
           duration={2500}
+          wrapperStyle={
+            isMobile
+              ? { top: 100, bottom: undefined, position: 'absolute' }
+              : undefined
+          }
         >
           {message}
         </Snackbar>

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,5 +1,7 @@
-import { createContext, useState } from 'react';
+import { createContext, useEffect, useState } from 'react';
 import { Snackbar } from 'react-native-paper';
+
+import { registerToast } from './toastController';
 
 interface ToastContetProps {
   showToast: (msg: string) => void;
@@ -17,6 +19,10 @@ export function ToastProvider({ children }: any) {
     setMessage(msg);
     setVisible(true);
   }
+
+  useEffect(() => {
+    registerToast(showToast);
+  }, []);
 
   return (
     <ToastContext.Provider value={{ showToast }}>

--- a/contexts/UserContext.tsx
+++ b/contexts/UserContext.tsx
@@ -1,10 +1,10 @@
 import React, { createContext, useEffect, useState } from 'react';
 
+import { showToastGlobal } from '@/contexts';
 import { useAuth } from '@/hooks';
 import { AuthService, Tecnico, TecnicoService, Usuario } from '@/services';
 import { Email } from '@/services/auth';
 import { UsuarioService } from '@/services/usuarios/usuario.service';
-import { showAlert } from '@/utils';
 
 interface UserContextProps {
   user: Usuario | Tecnico | null;
@@ -62,7 +62,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       setUser(resolvedUser);
       setUserType(tecnico ? 'Tecnico' : usuario ? 'Usuario' : null);
     } catch {
-      showAlert('Erro', 'Não foi possível carregar os dados do usuário.');
+      showToastGlobal('Não foi possível carregar os dados do usuário.');
     } finally {
       setUserLoading(false);
     }

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,3 +1,4 @@
 export * from './AuthContext';
 export * from './ToastContext';
+export * from './toastController';
 export * from './UserContext';

--- a/contexts/index.ts
+++ b/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from './AuthContext';
+export * from './ToastContext';
 export * from './UserContext';

--- a/contexts/toastController.ts
+++ b/contexts/toastController.ts
@@ -1,0 +1,9 @@
+let toastFn: ((msg: string) => void) | null = null;
+
+export function registerToast(fn: (msg: string) => void) {
+  toastFn = fn;
+}
+
+export function showToastGlobal(message: string) {
+  if (toastFn) toastFn(message);
+}

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useAuth';
+export * from './useToast';
 export * from './useUser';

--- a/hooks/useToast.ts
+++ b/hooks/useToast.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+
+import { ToastContext } from '@/contexts';
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,11 @@
         "react-native": "0.81.4",
         "react-native-element-dropdown": "^2.12.4",
         "react-native-gesture-handler": "~2.28.0",
+        "react-native-paper": "^5.14.5",
         "react-native-reanimated": "~4.1.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-vector-icons": "^10.3.0",
         "react-native-web": "~0.21.0",
         "react-native-webview": "^13.16.0",
         "react-native-worklets": "0.5.1"
@@ -1536,6 +1538,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@callstack/react-theme-provider/-/react-theme-provider-3.0.9.tgz",
+      "integrity": "sha512-tTQ0uDSCL0ypeMa8T/E9wAZRGKWj8kXP7+6RYgPTfOPs9N07C9xM8P02GJ3feETap4Ux5S69D9nteq9mEj86NA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^3.2.0",
+        "hoist-non-react-statics": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@callstack/react-theme-provider/node_modules/deepmerge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@egjs/hammerjs": {
@@ -10680,7 +10704,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10692,7 +10715,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -10952,6 +10974,51 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-paper": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.14.5.tgz",
+      "integrity": "sha512-eaIH5bUQjJ/mYm4AkI6caaiyc7BcHDwX6CqNDi6RIxfxfWxROsHpll1oBuwn/cFvknvA8uEAkqLk/vzVihI3AQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example",
+        "docs"
+      ],
+      "dependencies": {
+        "@callstack/react-theme-provider": "^3.0.9",
+        "color": "^3.1.2",
+        "use-latest-callback": "^0.2.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-safe-area-context": "*"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/react-native-paper/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
     "node_modules/react-native-reanimated": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.0.tgz",
@@ -11003,6 +11070,110 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.3.0.tgz",
+      "integrity": "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw==",
+      "deprecated": "react-native-vector-icons package has moved to a new model of per-icon-family packages. See the https://github.com/oblador/react-native-vector-icons/blob/master/MIGRATION.md on how to migrate",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa-upgrade.sh": "bin/fa-upgrade.sh",
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "fa6-upgrade": "bin/fa6-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-vector-icons/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "react-native": "0.81.4",
     "react-native-element-dropdown": "^2.12.4",
     "react-native-gesture-handler": "~2.28.0",
+    "react-native-paper": "^5.14.5",
     "react-native-reanimated": "~4.1.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-vector-icons": "^10.3.0",
     "react-native-web": "~0.21.0",
     "react-native-webview": "^13.16.0",
     "react-native-worklets": "0.5.1"

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
+import { showToastGlobal } from '@/contexts';
 import { getToken } from '@/services/auth/storage';
-import { showAlert } from '@/utils/notifications';
 
 let logoutCallback: (() => Promise<void>) | null = null;
 
@@ -33,21 +33,20 @@ api.interceptors.response.use(
     const response = error.response;
 
     if (!response) {
-      showAlert('Erro de rede', 'Não foi possível se conectar ao servidor.');
+      showToastGlobal('Não foi possível se conectar ao servidor.');
       return Promise.reject(error);
     }
 
     const status: number = response.status;
     const message: string = response.data?.message || 'Ocorreu um erro inesperado. Tente novamente.';
 
-    if (status === 401) {
-      showAlert('Sessão expirada', 'Por favor, faça login novamente.');
+    if (status === 403) {
+      showToastGlobal('Por favor, faça login novamente.');
 
       if (logoutCallback) {
         await logoutCallback();
       }
     }
-
 
     return Promise.reject({
       status,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,2 +1,1 @@
-export * from './notifications';
 export * from './request';

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,9 +1,0 @@
-import { Alert, Platform } from 'react-native';
-
-export function showAlert(title: string, message: string): void {
-  if (Platform.OS === 'web') {
-    window.alert(`${title}\n\n${message}`);
-    return;
-  }
-  Alert.alert(title, message);
-}


### PR DESCRIPTION
O utilitário showAlert foi substituído pelo hook useToast e pelo toastController.

Agora a mensagem de credenciais inválidas só aparece quando o status do erro é 401.